### PR TITLE
Add GuidConverter example

### DIFF
--- a/tests/Jet.JsonNet.Converters.Tests/PicklerTests.fs
+++ b/tests/Jet.JsonNet.Converters.Tests/PicklerTests.fs
@@ -2,8 +2,10 @@
 
 open Newtonsoft.Json.Converters.FSharp
 open Newtonsoft.Json
+open Swensen.Unquote
 open System
 open System.Runtime.Serialization
+open Xunit
 
 /// Endows any type that inherits this class with standard .NET comparison semantics using a supplied token identifier
 [<AbstractClass>]
@@ -57,3 +59,18 @@ and private CartIdJsonConverter() =
     override __.Pickle value = value.Value
     /// Input must be a Guid.Parseable value
     override __.UnPickle input = CartId.Parse input
+
+/// <summary>
+///     Renders all Guids without dashes.
+/// </summary>
+/// <remarks>
+///     Can work correctly as a global converter, as some codebases do for historical reasons
+///     Could arguably be usable as base class for various converters, including the above.
+///     However, the above pattern and variants thereof are recommended for new types.
+///     In general, the philosophy is that, beyond the Pickler base types, an identiy type should consist of explicit
+///       code as much as possible, and global converters really have to earn their keep - magic starts with -100 points.
+/// </remarks>
+type GuidConverter() =
+    inherit JsonIsomorphism<Guid, string>()
+    override __.Pickle g = g.ToString "N"
+    override __.UnPickle g = Guid.Parse g

--- a/tests/Jet.JsonNet.Converters.Tests/PicklerTests.fs
+++ b/tests/Jet.JsonNet.Converters.Tests/PicklerTests.fs
@@ -60,17 +60,41 @@ and private CartIdJsonConverter() =
     /// Input must be a Guid.Parseable value
     override __.UnPickle input = CartId.Parse input
 
-/// <summary>
-///     Renders all Guids without dashes.
-/// </summary>
-/// <remarks>
-///     Can work correctly as a global converter, as some codebases do for historical reasons
-///     Could arguably be usable as base class for various converters, including the above.
-///     However, the above pattern and variants thereof are recommended for new types.
-///     In general, the philosophy is that, beyond the Pickler base types, an identiy type should consist of explicit
-///       code as much as possible, and global converters really have to earn their keep - magic starts with -100 points.
-/// </remarks>
-type GuidConverter() =
-    inherit JsonIsomorphism<Guid, string>()
-    override __.Pickle g = g.ToString "N"
-    override __.UnPickle g = Guid.Parse g
+module JsonIsomorphismTests =
+
+    // NB Feel free to ignore this opinion and copy the 4 lines into your own globals - the pinning test will remain here
+    /// <summary>
+    ///     Renders all Guids without dashes.
+    /// </summary>
+    /// <remarks>
+    ///     Can work correctly as a global converter, as some codebases do for historical reasons
+    ///     Could arguably be usable as base class for various converters, including the above.
+    ///     However, the above pattern and variants thereof are recommended for new types.
+    ///     In general, the philosophy is that, beyond the Pickler base types, an identiy type should consist of explicit
+    ///       code as much as possible, and global converters really have to earn their keep - magic starts with -100 points.
+    /// </remarks>
+    type GuidConverter() =
+        inherit JsonIsomorphism<Guid, string>()
+        override __.Pickle g = g.ToString "N"
+        override __.UnPickle g = Guid.Parse g
+
+    type WithEmbeddedGuid = { a: string; [<JsonConverter(typeof<GuidConverter>)>] b: Guid }
+
+    let [<Fact>] ``Tagging with GuidConverter`` () =
+        let value = { a = "testing"; b = Guid.Empty }
+
+        let result = JsonConvert.SerializeObject value
+
+        test <@ """{"a":"testing","b":"00000000000000000000000000000000"}""" = result @>
+
+    let [<Fact>] ``Global GuidConverter`` () =
+        let settings = Settings.CreateDefault()
+        let value = Guid.Empty
+
+        let resDashes = JsonConvert.SerializeObject(value, settings)
+
+        settings.Converters.Add(new GuidConverter())
+        let resNoDashes = JsonConvert.SerializeObject(value, settings)
+
+        test <@ "\"00000000-0000-0000-0000-000000000000\"" = resDashes
+                && "\"00000000000000000000000000000000\"" = resNoDashes @>


### PR DESCRIPTION
A number of codebases register a global Guid rendering customization.

This PR adds such a converter as an acceptance test, with a comment explaining the rationale for not including it as a top level converter within the package itself.