### PR TITLE
Apply converters to tupled fields in UnionConverter to missing values fixes #1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project ToolsVersion="15.0">
 
   <PropertyGroup>
-    <VersionPrefix>0.0.1</VersionPrefix>
+    <VersionPrefix>0.0.2</VersionPrefix>
     <Authors>@jet @amjjd @eiriktsarpalis and contributors</Authors>
     <Company>Jet.com</Company>
     <Description>Simple version-tolerant Newtonsoft.Json Converters for F# types</Description>

--- a/Jet.JsonNet.Converters.sln
+++ b/Jet.JsonNet.Converters.sln
@@ -9,7 +9,12 @@ Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "Jet.JsonNet.Converters.Test
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".project", ".project", "{1D0127A7-2F3E-4CEF-90C6-621DA1192875}"
 	ProjectSection(SolutionItems) = preProject
+		build.cmd = build.cmd
+		Directory.Build.props = Directory.Build.props
+		global.json = global.json
+		LICENSE = LICENSE
 		README.md = README.md
+		SECURITY.md = SECURITY.md
 	EndProjectSection
 EndProject
 Global

--- a/src/Jet.JsonNet.Converters/Pickler.fs
+++ b/src/Jet.JsonNet.Converters/Pickler.fs
@@ -74,11 +74,17 @@ type Settings private () =
     /// </summary>
     /// <param name="camelCase">Render idiomatic camelCase for PascalCase items by using `CamelCasePropertyNamesContractResolver`. Defaults to true.</param>
     /// <param name="indent">Use multi-line, indented formatting when serializing json; defaults to false.</param>
+    /// <param name="ignoreNulls">Ignore null values in input data; defaults to true. NB OOTB, Json.Net defaults to false.</param>
+    /// <param name="errorOnMissing">Error on missing values (as opposed to letting them just be default-initialized); defaults to false.</param>
     static member CreateDefault
         (   [<Optional;DefaultParameterValue(null)>]?indent : bool,
-            [<Optional;DefaultParameterValue(null)>]?camelCase : bool) =
+            [<Optional;DefaultParameterValue(null)>]?camelCase : bool,
+            [<Optional;DefaultParameterValue(null)>]?ignoreNulls : bool,
+            [<Optional;DefaultParameterValue(null)>]?errorOnMissing : bool) =
         let indent = defaultArg indent false
         let camelCase = defaultArg camelCase true
+        let ignoreNulls = defaultArg ignoreNulls true
+        let errorOnMissing = defaultArg errorOnMissing false
         let resolver : IContractResolver =
              if camelCase then CamelCasePropertyNamesContractResolver() :> _
              else DefaultContractResolver() :> _
@@ -87,4 +93,5 @@ type Settings private () =
             DateTimeZoneHandling = DateTimeZoneHandling.Utc,
             DateFormatHandling = DateFormatHandling.IsoDateFormat,
             Formatting = (if indent then Formatting.Indented else Formatting.None),
-            NullValueHandling = NullValueHandling.Ignore)
+            MissingMemberHandling = (if errorOnMissing then MissingMemberHandling.Error else MissingMemberHandling.Ignore),
+            NullValueHandling = (if ignoreNulls then NullValueHandling.Ignore else NullValueHandling.Include))

--- a/src/Jet.JsonNet.Converters/TypeSafeEnumConverter.fs
+++ b/src/Jet.JsonNet.Converters/TypeSafeEnumConverter.fs
@@ -40,6 +40,7 @@ type TypeSafeEnumConverter() =
         writer.WriteValue str
 
     override __.ReadJson(reader, t: Type, _: obj, _: JsonSerializer) =
-        if reader.TokenType <> JsonToken.String then raise (JsonSerializationException "Unexpected token when reading TypeSafeEnum")
+        if reader.TokenType <> JsonToken.String then
+            sprintf "Unexpected token when reading TypeSafeEnum: %O" reader.TokenType |> JsonSerializationException |> raise
         let str = reader.Value :?> string
         TypeSafeEnum.parseT t str

--- a/src/Jet.JsonNet.Converters/UnionConverter.fs
+++ b/src/Jet.JsonNet.Converters/UnionConverter.fs
@@ -53,6 +53,8 @@ module private Union =
         | multipleFieldsInCustomCaseType ->
             [| for fi in multipleFieldsInCustomCaseType ->
                 match inputJObject.[fi.Name] with
+                | null when typeHasJsonConverterAttribute fi.PropertyType ->
+                        JToken.Parse("null").ToObject(fi.PropertyType, jsonSerializer)
                 | null -> null
                 | itemValue -> itemValue.ToObject(fi.PropertyType, jsonSerializer) |]
 


### PR DESCRIPTION
A `TypeSafeEnum` when used as a tupled field is not validated and simply yields a `null` (and subsequent `NullReferenceException`s).

This fix addresses that by triggering an exception on conversion.

Note: this is debatable - my reasoning for making this a default behavior is that a converters can be made to cope with this signalling by having a specific handing for a `JToken.Null` input, and that the scope is limited to tupled Union cases using the `UnionConverter`

A follow-up PR will allow one to opt-in to handing this missing field case by wrapping the value in an `Option`